### PR TITLE
Update SonarQube Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ You can take a look at the script
 of this project to see it in practice.
 
 ## Links
-- [Documentation of the C/C++/Objective-C plugin and its with Build Wrapper](http://docs.sonarqube.org/x/pwAv)
+- [Documentation of the C/C++/Objective-C plugin and its with Build Wrapper](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/c-family/)


### PR DESCRIPTION
I suggest reviewing the whole example repositories set as I found broken links there as well.